### PR TITLE
Fix CORS for register endpoint

### DIFF
--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -15,7 +15,8 @@
     */
 return [
 
-    'paths' => ['api/*', 'login', 'logout', 'sanctum/csrf-cookie', 'email/*'],
+    // 추가: 회원가입 API 호출을 위한 '/register' 경로 허용
+    'paths' => ['api/*', 'login', 'logout', 'register', 'sanctum/csrf-cookie', 'email/*'],
 
     'allowed_methods' => ['*'],
 


### PR DESCRIPTION
## Summary
- allow `/register` route through CORS

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e35f850c83229fe8ed72a00e565e